### PR TITLE
Allow check to follow redirects

### DIFF
--- a/bin/check
+++ b/bin/check
@@ -20,7 +20,7 @@ jq -r '.source.sources[]' /tmp/input | while read SOURCE; do
 
   for COMP in $COMPONENTS; do
     echo -n "  $COMP"
-    curl --silent --show-error --head --time-cond /tmp/last --remote-time \
+    curl -L --silent --show-error --head --time-cond /tmp/last --remote-time \
       --output /tmp/curl "$URI/dists/$SUITE/$COMP/binary-$ARCH/Release"
     if grep -q '^HTTP/... 200 ' /tmp/curl; then
       echo -n -e " ${GREEN}updated!${RESET}"

--- a/bin/check
+++ b/bin/check
@@ -20,8 +20,8 @@ jq -r '.source.sources[]' /tmp/input | while read SOURCE; do
 
   for COMP in $COMPONENTS; do
     echo -n "  $COMP"
-    curl -L --silent --show-error --head --time-cond /tmp/last --remote-time \
-      --output /tmp/curl "$URI/dists/$SUITE/$COMP/binary-$ARCH/Release"
+    curl --location --max-redirs 1 --silent --show-error --head --time-cond /tmp/last \
+      --remote-time --output /tmp/curl "$URI/dists/$SUITE/$COMP/binary-$ARCH/Release"
     if grep -q '^HTTP/... 200 ' /tmp/curl; then
       echo -n -e " ${GREEN}updated!${RESET}"
       touch --reference=/tmp/curl /tmp/last


### PR DESCRIPTION
So http redirect sources work properly. For instance:

```
deb http://httpredir.debian.org/debian jessie main
```

would never trigger an update since it always returns a 302 redirect. -L tells curl to follow that and get the actual source to check.
